### PR TITLE
feat: make URLs in chat messages clickable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-desktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-desktop",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-shell": "^2",

--- a/src/components/LinkifiedText.tsx
+++ b/src/components/LinkifiedText.tsx
@@ -1,0 +1,67 @@
+import { openUrl } from "../lib/shell";
+
+/**
+ * Regex to match URLs in plain text.
+ * Matches http://, https://, and ftp:// URLs.
+ * Avoids trailing punctuation (.,;:!?) unless inside parens.
+ */
+const URL_REGEX = /\bhttps?:\/\/[^\s<>[\]"'`]+[^\s<>[\]"'`.,;:!?)]/gi;
+
+interface Props {
+  text: string;
+}
+
+/**
+ * Renders plain text with detected URLs as clickable links.
+ * Used for user and error messages (which don't go through markdown).
+ */
+export default function LinkifiedText({ text }: Props) {
+  const parts: (string | { url: string; key: number })[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let keyCounter = 0;
+
+  // Reset regex state
+  URL_REGEX.lastIndex = 0;
+
+  while ((match = URL_REGEX.exec(text)) !== null) {
+    // Add text before the URL
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    parts.push({ url: match[0], key: keyCounter++ });
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Add remaining text
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  // If no URLs found, return plain text
+  if (parts.length === 1 && typeof parts[0] === "string") {
+    return <>{text}</>;
+  }
+
+  return (
+    <>
+      {parts.map((part) =>
+        typeof part === "string" ? (
+          part
+        ) : (
+          <a
+            key={part.key}
+            href={part.url}
+            onClick={(e) => {
+              e.preventDefault();
+              openUrl(part.url);
+            }}
+            className="cursor-pointer text-claw-amber underline underline-offset-2 hover:text-claw-amber-light"
+          >
+            {part.url}
+          </a>
+        )
+      )}
+    </>
+  );
+}

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -1,6 +1,7 @@
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
+import { openUrl } from "../lib/shell";
 
 const components: Components = {
   p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
@@ -25,9 +26,11 @@ const components: Components = {
   a: ({ href, children }) => (
     <a
       href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="text-claw-amber underline underline-offset-2 hover:text-claw-amber-light"
+      onClick={(e) => {
+        e.preventDefault();
+        if (href) openUrl(href);
+      }}
+      className="cursor-pointer text-claw-amber underline underline-offset-2 hover:text-claw-amber-light"
     >
       {children}
     </a>

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,4 +1,5 @@
 import type { Message } from "../lib/types";
+import LinkifiedText from "./LinkifiedText";
 import CopyButton from "./CopyButton";
 import MarkdownContent from "./MarkdownContent";
 
@@ -14,7 +15,6 @@ export default function MessageBubble({ message, agentEmoji }: Props) {
 
   return (
     <div className={`flex items-end gap-2.5 ${isUser ? "flex-row-reverse" : "flex-row"}`}>
-      {/* Avatar (only for non-user messages) */}
       {!isUser && (
         <div
           className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md border text-sm ${
@@ -27,7 +27,6 @@ export default function MessageBubble({ message, agentEmoji }: Props) {
         </div>
       )}
 
-      {/* Bubble */}
       <div className="group relative max-w-[68%]">
         <CopyButton
           text={message.text || ""}
@@ -40,27 +39,27 @@ export default function MessageBubble({ message, agentEmoji }: Props) {
             isUser
               ? "rounded-[10px_10px_2px_10px] border-claw-user-border bg-claw-user-bg"
               : isError
-              ? "rounded-[10px_10px_10px_2px] border-claw-error-border bg-claw-error-bg"
-              : "rounded-[10px_10px_10px_2px] border-claw-border bg-claw-surface"
+                ? "rounded-[10px_10px_10px_2px] border-claw-error-border bg-claw-error-bg"
+                : "rounded-[10px_10px_10px_2px] border-claw-border bg-claw-surface"
           }`}
         >
-        <div
-          className={`break-words text-[13px] leading-relaxed ${
-            isUser
-              ? "whitespace-pre-wrap text-claw-amber-light"
-              : isError
-              ? "whitespace-pre-wrap text-red-400"
-              : "text-[#d4d4d8]"
-          }`}
-        >
-          {isUser || isError ? (
-            message.text || "(empty reply)"
-          ) : (
-            <MarkdownContent content={message.text || "(empty reply)"} />
-          )}
+          <div
+            className={`break-words text-[13px] leading-relaxed ${
+              isUser
+                ? "whitespace-pre-wrap text-claw-amber-light"
+                : isError
+                  ? "whitespace-pre-wrap text-red-400"
+                  : "text-[#d4d4d8]"
+            }`}
+          >
+            {isUser || isError ? (
+              <LinkifiedText text={message.text || "(empty reply)"} />
+            ) : (
+              <MarkdownContent content={message.text || "(empty reply)"} />
+            )}
+          </div>
+          <div className="mt-1.5 text-right text-[9px] text-claw-dim">{ts}</div>
         </div>
-        <div className="mt-1.5 text-right text-[9px] text-claw-dim">{ts}</div>
-      </div>
       </div>
     </div>
   );

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -1,0 +1,14 @@
+import { open } from "@tauri-apps/plugin-shell";
+
+/**
+ * Open a URL in the user's default browser via Tauri shell API.
+ * Falls back to window.open() when running outside Tauri (e.g. dev in browser).
+ */
+export async function openUrl(url: string): Promise<void> {
+  try {
+    await open(url);
+  } catch {
+    // Fallback for dev mode in browser (no Tauri runtime)
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+}


### PR DESCRIPTION
## Summary

URLs in chat messages are now clickable and open in the user's default browser via Tauri's shell API.

Fixes #7

## Changes

### New files
- **`src/components/LinkifiedText.tsx`** — Detects URLs in plain text (user/error messages) and renders them as clickable `<a>` tags
- **`src/lib/shell.ts`** — Wrapper around `@tauri-apps/plugin-shell` `open()` with fallback to `window.open()` for dev mode

### Modified files
- **`src/components/MarkdownContent.tsx`** — Updated `<a>` handler to use Tauri shell API instead of `target=\"_blank\"` (which doesn't work properly in WebView)
- **`src/components/MessageBubble.tsx`** — User and error messages now use `LinkifiedText` instead of rendering plain text

## How it works

| Message type | URL handling |
|---|---|
| **Assistant** (markdown) | `remark-gfm` autolinks + `MarkdownContent` `<a>` component → Tauri shell |
| **User** (plain text) | `LinkifiedText` regex detection → Tauri shell |
| **Error** (plain text) | `LinkifiedText` regex detection → Tauri shell |

## Acceptance Criteria

- [x] Plain URLs in messages rendered as clickable links
- [x] Clicking a link opens the default browser (via Tauri shell)
- [x] URLs in code blocks/inline code left as plain text (handled by markdown renderer)
- [x] No regressions — `tsc --noEmit` and `lint` pass clean