### PR TITLE
feat: add visual indicator for new unread replies

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,7 +7,9 @@ function AgentRow({ agent }: { agent: Agent }) {
   const messageCount = useStore(
     (s) => (s.messages[agent.id] ?? []).length,
   );
+  const unreadCount = useStore((s) => s.unreadCounts[agent.id] ?? 0);
   const isActive = agent.id === activeAgentId;
+  const hasUnread = unreadCount > 0;
 
   const emoji = agent.identity?.emoji ?? "🤖";
   const displayName = agent.identity?.name ?? agent.name ?? agent.id;
@@ -18,13 +20,15 @@ function AgentRow({ agent }: { agent: Agent }) {
       className={`flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left transition-all duration-150 ${
         isActive
           ? "border border-claw-border-hover bg-claw-card"
-          : "border border-transparent hover:bg-claw-card/50"
+          : hasUnread
+            ? "border border-claw-amber/40 bg-claw-amber/10 hover:bg-claw-amber/15"
+            : "border border-transparent hover:bg-claw-card/50"
       }`}
       style={{ marginBottom: 3 }}
     >
       <span className="text-base">{emoji}</span>
       <div className="flex-1 min-w-0">
-        <div className={`truncate text-xs ${isActive ? "font-semibold text-claw-text-bright" : "text-claw-text-muted"}`}>
+        <div className={`truncate text-xs ${isActive ? "font-semibold text-claw-text-bright" : hasUnread ? "font-semibold text-claw-amber-light" : "text-claw-text-muted"}`}>
           {displayName}
         </div>
         <div className="flex items-center gap-1 text-[10px] text-claw-green">
@@ -33,7 +37,14 @@ function AgentRow({ agent }: { agent: Agent }) {
         </div>
       </div>
       {messageCount > 0 && (
-        <span className="rounded bg-claw-border px-1.5 py-px text-[9px] text-claw-subtle">
+        <span
+          className={`inline-flex min-w-[22px] items-center justify-center gap-1 rounded px-1.5 py-px text-[9px] transition-all duration-150 ${
+            hasUnread
+              ? "bg-claw-amber text-claw-bg"
+              : "bg-claw-border text-claw-subtle"
+          }`}
+        >
+          {hasUnread && <span className="inline-block h-[5px] w-[5px] rounded-full bg-claw-bg/80" />}
           {messageCount}
         </span>
       )}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -21,6 +21,9 @@ interface AppState {
   // Messages — keyed by agent id
   messages: Record<string, Message[]>;
 
+  // Visual notification state per agent
+  unreadCounts: Record<string, number>;
+
   // Loading per agent
   sending: Record<string, boolean>;
 
@@ -44,6 +47,7 @@ export const useStore = create<AppState>()(
       agents: [],
       activeAgentId: null,
       messages: {},
+      unreadCounts: {},
       sending: {},
 
       setEndpoint: (ep) => set({ endpoint: ep }),
@@ -60,6 +64,7 @@ export const useStore = create<AppState>()(
             endpoint,
             token,
             activeAgentId: result.default_id ?? result.agents[0]?.id ?? null,
+            unreadCounts: {},
           });
         } catch (err) {
           set({
@@ -75,13 +80,20 @@ export const useStore = create<AppState>()(
           agents: [],
           activeAgentId: null,
           connectionError: null,
+          unreadCounts: {},
         }),
 
-      setActiveAgent: (id) => set({ activeAgentId: id }),
+      setActiveAgent: (id) =>
+        set((state) => ({
+          activeAgentId: id,
+          unreadCounts: { ...state.unreadCounts, [id]: 0 },
+        })),
 
       sendMessage: async (text) => {
         const { activeAgentId, messages, sending } = get();
         if (!activeAgentId || sending[activeAgentId]) return;
+
+        const targetAgentId = activeAgentId;
 
         const userMsg: Message = {
           id: uuidv4(),
@@ -93,26 +105,33 @@ export const useStore = create<AppState>()(
         set({
           messages: {
             ...messages,
-            [activeAgentId]: [...(messages[activeAgentId] ?? []), userMsg],
+            [targetAgentId]: [...(messages[targetAgentId] ?? []), userMsg],
           },
-          sending: { ...sending, [activeAgentId]: true },
+          sending: { ...sending, [targetAgentId]: true },
         });
 
         try {
-          const reply = await api.sendMessage(activeAgentId, text);
+          const reply = await api.sendMessage(targetAgentId, text);
           const assistantMsg: Message = {
             id: uuidv4(),
             role: "assistant",
             text: reply.reply,
             ts: reply.timestamp,
           };
-          set((state) => ({
-            messages: {
-              ...state.messages,
-              [activeAgentId]: [...(state.messages[activeAgentId] ?? []), assistantMsg],
-            },
-            sending: { ...state.sending, [activeAgentId]: false },
-          }));
+          set((state) => {
+            const isUnread = get().activeAgentId !== targetAgentId;
+            return {
+              messages: {
+                ...state.messages,
+                [targetAgentId]: [...(state.messages[targetAgentId] ?? []), assistantMsg],
+              },
+              unreadCounts: {
+                ...state.unreadCounts,
+                [targetAgentId]: isUnread ? (state.unreadCounts[targetAgentId] ?? 0) + 1 : 0,
+              },
+              sending: { ...state.sending, [targetAgentId]: false },
+            };
+          });
         } catch (err) {
           const errorMsg: Message = {
             id: uuidv4(),
@@ -120,19 +139,27 @@ export const useStore = create<AppState>()(
             text: err instanceof Error ? err.message : String(err),
             ts: Date.now(),
           };
-          set((state) => ({
-            messages: {
-              ...state.messages,
-              [activeAgentId]: [...(state.messages[activeAgentId] ?? []), errorMsg],
-            },
-            sending: { ...state.sending, [activeAgentId]: false },
-          }));
+          set((state) => {
+            const isUnread = get().activeAgentId !== targetAgentId;
+            return {
+              messages: {
+                ...state.messages,
+                [targetAgentId]: [...(state.messages[targetAgentId] ?? []), errorMsg],
+              },
+              unreadCounts: {
+                ...state.unreadCounts,
+                [targetAgentId]: isUnread ? (state.unreadCounts[targetAgentId] ?? 0) + 1 : 0,
+              },
+              sending: { ...state.sending, [targetAgentId]: false },
+            };
+          });
         }
       },
 
       clearMessages: (agentId) =>
         set((state) => ({
           messages: { ...state.messages, [agentId]: [] },
+          unreadCounts: { ...state.unreadCounts, [agentId]: 0 },
         })),
     }),
     {


### PR DESCRIPTION
## Summary
- add per-agent unread reply tracking in the Zustand store
- highlight sidebar rows and badges when a thread receives a new unseen reply
- clear the indicator automatically when the user opens or clears that thread

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

Closes #20