### PR TITLE
fix: repair version check workflow syntax

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -21,15 +21,15 @@ jobs:
           package_version=$(node -p "require('./package.json').version")
           tauri_version=$(node -p "require('./src-tauri/tauri.conf.json').version")
           cargo_version=$(python3 - <<'PY'
-from pathlib import Path
-import re
-content = Path('src-tauri/Cargo.toml').read_text()
-match = re.search(r'^version = "([^"]+)"$', content, re.MULTILINE)
-if not match:
-    raise SystemExit('Could not find Cargo version')
-print(match.group(1))
-PY
-)
+          from pathlib import Path
+          import re
+          content = Path('src-tauri/Cargo.toml').read_text()
+          match = re.search(r'^version = "([^"]+)"$', content, re.MULTILINE)
+          if not match:
+              raise SystemExit('Could not find Cargo version')
+          print(match.group(1))
+          PY
+          )
 
           echo "package.json: $package_version"
           echo "tauri.conf.json: $tauri_version"


### PR DESCRIPTION
## Summary
- fix the YAML structure in `.github/workflows/version-check.yml`
- keep the version consistency check logic intact for `package.json`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml`
- preserve the existing shell/Python-based version extraction flow

## Testing
- parsed `.github/workflows/version-check.yml` locally with PyYAML
- ran the version consistency shell logic locally and confirmed all three version values still match

Closes #22