### PR TITLE
chore: bump version to 0.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-desktop",
-  "version": "0.2.0",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-desktop",
-      "version": "0.2.0",
+      "version": "0.2.3",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-shell": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openclaw-desktop",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "openclaw-desktop"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openclaw-desktop"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "OpenClaw Desktop",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "com.openclaw.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- bump OpenClaw Desktop version from `0.2.2` to `0.2.3`
- update npm and Cargo lock metadata for the release

## Release notes basis
Changes since `v0.2.2`:
- allow external links to open in the browser
- add visual unread reply indicators
- fix the version-check workflow syntax

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `npm run lint`
- `npm run test`
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --locked -- -D warnings`
- `git diff --check`

After this PR lands, release tag should be `v0.2.3`.